### PR TITLE
Auto-detect install dir

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -115,6 +115,11 @@ const generateTemplate = (): MenuItemConstructorOptions[] => [
         label: 'Download Cache',
         click: () =>
           shell.openItem(path.join(app.getPath('userData'), 'downloadCache'))
+      },
+      {
+        label: 'Temporary files',
+        click: () =>
+          shell.openItem(path.join(app.getPath('temp'), app.getName()))
       }
     ]
   },

--- a/src/app/core/services/electron.service.ts
+++ b/src/app/core/services/electron.service.ts
@@ -28,7 +28,8 @@ export class ElectronService {
   fs: typeof fs;
   path: typeof path;
   unzipper: typeof unzipper;
-  glob: typeof glob;
+
+  private _glob: typeof glob;
 
   constructor() {
     // Conditional imports
@@ -45,7 +46,7 @@ export class ElectronService {
       this.fs = this.remote.require('fs-extra');
       this.path = this.remote.require('path');
       this.unzipper = this.remote.require('unzipper');
-      this.glob = this.remote.require('glob');
+      this._glob = this.remote.require('glob');
 
       this.configureIpc();
     }
@@ -66,6 +67,18 @@ export class ElectronService {
       return this.remote.dialog.showMessageBox(win, opts);
     }
   }
+
+  glob = (pattern: string, opts?: glob.IOptions): Promise<string[]> => {
+    return new Promise((resolve, reject) => {
+      this._glob(pattern, opts, (err, matches) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(matches);
+        }
+      });
+    });
+  };
 
   showConfirmBox(
     opts: ConfirmBoxOptions,

--- a/src/app/main/config-editor/found-config-table/found-config-table.component.ts
+++ b/src/app/main/config-editor/found-config-table/found-config-table.component.ts
@@ -23,15 +23,13 @@ export class FoundConfigTableComponent implements OnInit {
     private ngZone: NgZone
   ) {}
 
-  ngOnInit() {
-    this.electron.glob(
-      `${this.prefs.get('ror2_path')}/BepInEx/config/*.cfg`,
-      (err, matches) => {
-        this.configFiles = matches.map(file => ({
-          filename: this.electron.path.basename(file)
-        }));
-        this.ngZone.run(() => this.changeDetector.detectChanges());
-      }
+  async ngOnInit() {
+    const matches = await this.electron.glob(
+      `${this.prefs.get('ror2_path')}/BepInEx/config/*.cfg`
     );
+    this.configFiles = matches.map(file => ({
+      filename: this.electron.path.basename(file)
+    }));
+    this.ngZone.run(() => this.changeDetector.detectChanges());
   }
 }


### PR DESCRIPTION
Attempt to auto-detect where a package would like to be install by searching for folders named `plugins`,  `monomod`, or `patchers` in the package zip. If it finds one or more of those folders, it will copy the contents of the folder to the corresponding folder in the BepInEx install. Otherwise, it will assume it's a `plugin` and install it there.

This resolves #78 