### PR TITLE
Fixed app breaking bug caused by non-existing dependencies

### DIFF
--- a/src/app/core/models/package.model.ts
+++ b/src/app/core/models/package.model.ts
@@ -152,6 +152,9 @@ export const deserializablePackageList = (
           const depPkg = packages.find(
             p => p.owner === owner && p.name === name
           );
+
+          if (!depPkg) return;
+
           const depVer = depPkg.versions.find(v =>
             satisfies(v.version, `~${versionNumber}`)
           );


### PR DESCRIPTION
Fixes #115 

App stopped working because one of the versions of a mod ([PixelFont](https://thunderstore.io/package/mistername/PixelFont/)) required a mod that no longer exist.

I fixed the bug by simply adding a condition that would add dependencies only if they exist.